### PR TITLE
Update 20-files-present-and-referenced to ignore .git and .emacs.backup

### DIFF
--- a/20-files-present-and-referenced
+++ b/20-files-present-and-referenced
@@ -289,7 +289,9 @@ for i in $DIR_TO_CHECK/* $DIR_TO_CHECK/.* ; do
 	_* | \
 	*.orig | \
 	*~ | \
+	.git | \
 	.gitignore | \
+	.emacs.backup | \
 	debian.changelog | \
 	debian.compat | \
 	debian.control | \


### PR DESCRIPTION
Self-explanatory :-)  I can't think of a scenario where these files should ever be referenced (and .gitignore is already on the list).
