### PR TITLE
Cleanup keyring check

### DIFF
--- a/20-files-present-and-referenced
+++ b/20-files-present-and-referenced
@@ -182,18 +182,17 @@ done
 # Verify GPG keys
 #
 
-shopt -s failglob
-if echo $DIR_TO_CHECK/*keyring 2>/dev/null ; then 
-	shopt -u failglob
-	gpg --no-default-keyring --keyring $TMPDIR/.checkifvalidsourcedir-gpg-keyring --import $DIR_TO_CHECK/*.keyring
-	shopt -s nullglob
-	for i in $DIR_TO_CHECK/*.sig $DIR_TO_CHECK/*.asc ; do 
-		gpg --no-default-keyring --keyring $TMPDIR/.checkifvalidsourcedir-gpg-keyring "$i"  ||  {
-			echo "(E) signature $i does not validate"
-			RETURN=2
-		}
-	done
-	rm $TMPDIR/.checkifvalidsourcedir-gpg-keyring
+if [ -f $DIR_TO_CHECK/*.keyring 2>/dev/null ]; then
+    gpg -q --no-default-keyring --keyring $TMPDIR/.checkifvalidsourcedir-gpg-keyring --import $DIR_TO_CHECK/*.keyring
+    for i in $DIR_TO_CHECK/*.sig $DIR_TO_CHECK/*.asc; do
+        if [ -f "$i" ]; then
+            gpg -q --no-default-keyring --keyring $TMPDIR/.checkifvalidsourcedir-gpg-keyring "$i" || {
+                echo "(E) signature $i does not validate"
+                RETURN=2
+            }
+        fi
+    done
+    rm $TMPDIR/.checkifvalidsourcedir-gpg-keyring
 fi
 
 #


### PR DESCRIPTION
- Avoid useless warning when no keyring exists
- Fix indenting
- Don't play with glob opts, breaks further checks
- Be quiet
