### PR TITLE
baselibs verification: targettype is a nown keyword - treat it as a '…

### DIFF
--- a/70-baselibs
+++ b/70-baselibs
@@ -16,6 +16,9 @@ containsElement () {
 # PASS if there is no baselibs.conf
 [ -f $DIR_TO_CHECK/baselibs.conf ] || exit 0
 
+# PASS if we have trouble parsing the .spec file
+rpm -q --specfile $DIR_TO_CHECK/*.spec >/dev/null 2>&1 || exit 0
+
 BUILTBINARIES=($(rpm -q --qf "%{name}\n" --specfile $DIR_TO_CHECK/*.spec))
 # add 'targettype' as a 'known keyword' to not trip over it
 BUILTBINARIES+=('targettype')

--- a/70-baselibs
+++ b/70-baselibs
@@ -17,7 +17,9 @@ containsElement () {
 [ -f $DIR_TO_CHECK/baselibs.conf ] || exit 0
 
 BUILTBINARIES=($(rpm -q --qf "%{name}\n" --specfile $DIR_TO_CHECK/*.spec))
-BASELIBSREF=$(grep "^\\S\+" $DIR_TO_CHECK/baselibs.conf)
+# add 'targettype' as a 'known keyword' to not trip over it
+BUILTBINARIES+=('targettype')
+BASELIBSREF=$(grep -o "^\\S\+" $DIR_TO_CHECK/baselibs.conf)
 
 RETURN=0
 for rpm in $BASELIBSREF; do


### PR DESCRIPTION
…built package'