### PR TITLE
Don't complain about Debian manpages files missing in *.spec

### DIFF
--- a/20-files-present-and-referenced
+++ b/20-files-present-and-referenced
@@ -417,6 +417,7 @@ for i in $DIR_TO_CHECK/* $DIR_TO_CHECK/.* ; do
 	debian.compat | \
 	debian.control | \
 	debian.copyright | \
+	debian.manpages | \
 	debian.postinst | \
 	debian.postrm | \
 	debian.preinst | \
@@ -432,6 +433,7 @@ for i in $DIR_TO_CHECK/* $DIR_TO_CHECK/.* ; do
 	debian.*.init | \
 	debian.*.install | \
 	debian.*.logrotate | \
+	debian.*.manpages | \
 	debian.*.postinst | \
 	debian.*.postrm | \
 	debian.*.preinst | \


### PR DESCRIPTION
Added `debian.manpages` and `debian.*.manpages` to the whitelist.

This [snapper submit request to Factory](https://build.opensuse.org/request/show/447293) was automatically rejected because it complained about missing `debian.*.manpages` files in the spec. It turned out that it's because the whitelist does not include this variant.