### PR TITLE
Fix service run mode check for localonly

### DIFF
--- a/20-files-present-and-referenced
+++ b/20-files-present-and-referenced
@@ -204,9 +204,9 @@ if [ -x $(type -p xmllint) ]; then
             xmllint --format $i > $TMPDIR/_service
 
             if egrep -q "service .*mode=." $TMPDIR/_service \
-                    && ! egrep -q "service .*mode=.(disabled|localrun|buildtime|explicit)" \
+                    && ! egrep -q "service .*mode=.(disabled|buildtime|explicit|localonly" \
                     $TMPDIR/_service; then
-                echo "(W) openSUSE: projects only allow 'disabled', 'buildtime', 'explicit' or 'localrun' services."
+                echo "(W) openSUSE: projects only allow 'disabled', 'buildtime', 'explicit' or 'localonly' services."
             fi
         fi
 


### PR DESCRIPTION
The correct value is localonly, not localrun, see
https://github.com/openSUSE/open-build-service/blob/67cb325884ab3340c3d71f978267f135e033a8f1/docs/api/api/obs.rng#L85