### PR TITLE
Add 80-multibuild_xor_multispec: multibuild XOR multispec is supported

### DIFF
--- a/80-multibuild_xor_multispec
+++ b/80-multibuild_xor_multispec
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+test "$1" = "--verbose" && { VERBOSE=true ; shift ; }
+test "$1" = "--batchmode" && { BATCHMODE=true ; shift ; }
+DIR_TO_CHECK=$1
+DESTINATIONDIR=$2
+test -n "$DIR_TO_CHECK" || DIR_TO_CHECK=`pwd`
+HELPERS_DIR="/usr/lib/obs/service/source_validators/helpers"
+$HELPERS_DIR/check_input_filename "$DIR_TO_CHECK" || exit 1
+test -z "$DESTINATIONDIR" -a -d "$DIR_TO_CHECK/.osc" && DESTINATIONDIR="$DIR_TO_CHECK/.osc"
+
+
+RETURN=0
+
+if [ -f "$DIR_TO_CHECK/_multibuild" -a $(ls -1 "$DIR_TO_CHECK/"*.spec | wc -l) -gt 1 ]; then
+	echo "ERROR: we support EITHER _multibuild OR multiple spec files. Do not add both"
+	RETURN=1
+fi
+
+exit $RETURN
+


### PR DESCRIPTION
Having multibuild AND multispec in place is confusing and for openSUSE:Factory leads
to problems, as the checkin bot automatically links up all additional spec file names
as sub-packages to the main package name.

If there is also a _multibuild file in it, all subpackages are built multiple times, e.g

With libproxy having libproxy.spec and libproxy-plugins.spec PLUS a multibuild, we would get
these package containts

(based on spec file names)
  libproxy
  libproxy-plugins
and assuming only libproxy-plugins be mentioned in _multibuild, additionally
libproxy:libproxy-plugins
  libproxy-plugins:libproxy-plugins