### PR TITLE
Remove provides and obsoletes from the spec

### DIFF
--- a/20-files-present-and-referenced
+++ b/20-files-present-and-referenced
@@ -117,6 +117,8 @@ for i in $DIR_TO_CHECK/*.spec ; do
 		/^Icon/d
 		/^Recommends/d
 		/^Supplements/d
+		/^Provides/d
+		/^Obsoletes/d
 		/^Suggests/d
 		/^Enhances/d
 		/^\([Ss]ource\|[Pp]atch\)[0-9]*:[ 	]*/{


### PR DESCRIPTION
This is not needed to be present in order to verify sources by rpmbuild and avoid errors with _multibuild packages.

source_validator"http://www.inf.puc-rio.br/~roberto/lpeg/lpeg-1.0.1.tar.gz error: line 29: Dependency tokens must begin with alpha-numeric, '_' or '/': Provides:       @BUILD_FLAVOR@-LPeg = 1.0.1