### PR TITLE
For signature verification, use trust model "always"

### DIFF
--- a/20-files-present-and-referenced
+++ b/20-files-present-and-referenced
@@ -254,7 +254,7 @@ fi
 #
 
 if [ -f $DIR_TO_CHECK/*.keyring 2>/dev/null ]; then
-    GPG_OPTIONS="-q --no-default-keyring --keyring $TMPDIR/.checkifvalidsourcedir-gpg-keyring"
+    GPG_OPTIONS="-q --no-default-keyring --keyring $TMPDIR/.checkifvalidsourcedir-gpg-keyring --trust-model always"
     gpg $GPG_OPTIONS --import $DIR_TO_CHECK/*.keyring
     for i in $DIR_TO_CHECK/*.sig $DIR_TO_CHECK/*.sign $DIR_TO_CHECK/*.asc; do
         if [ -f "$i" ]; then

--- a/20-files-present-and-referenced
+++ b/20-files-present-and-referenced
@@ -254,14 +254,15 @@ fi
 #
 
 if [ -f $DIR_TO_CHECK/*.keyring 2>/dev/null ]; then
-    gpg -q --no-default-keyring --keyring $TMPDIR/.checkifvalidsourcedir-gpg-keyring --import $DIR_TO_CHECK/*.keyring
+    GPG_OPTIONS="-q --no-default-keyring --keyring $TMPDIR/.checkifvalidsourcedir-gpg-keyring"
+    gpg $GPG_OPTIONS --import $DIR_TO_CHECK/*.keyring
     for i in $DIR_TO_CHECK/*.sig $DIR_TO_CHECK/*.sign $DIR_TO_CHECK/*.asc; do
         if [ -f "$i" ]; then
 	    validatefn=${i%.asc}
 	    validatefn=${validatefn%.sig}
 	    validatefn=${validatefn%.sign}
 	    if [ -f "$validatefn" ]; then
-                gpg -q --no-default-keyring --keyring $TMPDIR/.checkifvalidsourcedir-gpg-keyring --verify "$i" || {
+                gpg $GPG_OPTIONS --verify "$i" || {
                     echo "(E) signature $i does not validate"
                     RETURN=2
                 }
@@ -269,7 +270,7 @@ if [ -f $DIR_TO_CHECK/*.keyring 2>/dev/null ]; then
 	        if [ -f "$validatefn.gz" ]; then
 		    TMPFILE=`mktemp`
 		    zcat "$validatefn.gz" > $TMPFILE
-                    gpg -q --no-default-keyring --keyring $TMPDIR/.checkifvalidsourcedir-gpg-keyring --verify "$i" "$TMPFILE" || {
+                    gpg $GPG_OPTIONS --verify "$i" "$TMPFILE" || {
                         echo "(E) signature $i does not validate"
                         RETURN=2
                     }
@@ -278,7 +279,7 @@ if [ -f $DIR_TO_CHECK/*.keyring 2>/dev/null ]; then
 	        if [ -f "$validatefn.bz2" ]; then
 		    TMPFILE=`mktemp`
 		    bzcat "$validatefn.bz2" > $TMPFILE
-                    gpg -q --no-default-keyring --keyring $TMPDIR/.checkifvalidsourcedir-gpg-keyring --verify "$i" "$TMPFILE" || {
+                    gpg $GPG_OPTIONS --verify "$i" "$TMPFILE" || {
                         echo "(E) signature $i does not validate"
                         RETURN=2
                     }
@@ -287,7 +288,7 @@ if [ -f $DIR_TO_CHECK/*.keyring 2>/dev/null ]; then
 	        if [ -f "$validatefn.xz" ]; then
 		    TMPFILE=`mktemp`
 		    xzcat "$validatefn.xz" > $TMPFILE
-                    gpg -q --no-default-keyring --keyring $TMPDIR/.checkifvalidsourcedir-gpg-keyring --verify "$i" "$TMPFILE" || {
+                    gpg $GPG_OPTIONS --verify "$i" "$TMPFILE" || {
                         echo "(E) signature $i does not validate"
                         RETURN=2
                     }


### PR DESCRIPTION
The only keyring used in the verification run is the one from the package .keyring file. Therefore no trust database or relationship exists. Use the "always" trust model, which moves the checking to what is in the package keyring.

Fixes #29