### PR TITLE
Ignore not referenced appimage.yml file

### DIFF
--- a/20-files-present-and-referenced
+++ b/20-files-present-and-referenced
@@ -420,6 +420,7 @@ for i in $DIR_TO_CHECK/* $DIR_TO_CHECK/.* ; do
 	.gitignore | \
 	.emacs.backup | \
 	PKGBUILD | \
+	appimage.yml | \
 	debian.changelog | \
 	debian.compat | \
 	debian.control | \


### PR DESCRIPTION
The appimage.yml file is used for an AppImage build. Hence, there is
no need to reference it in the spec file.