### PR TITLE
Fix typo in egrep _service

### DIFF
--- a/20-files-present-and-referenced
+++ b/20-files-present-and-referenced
@@ -125,7 +125,7 @@ if [ -x $(type -p xmllint) ]; then
             xmllint --format $i > $TMPDIR/_service
 
             if egrep -q "service .*mode=." $TMPDIR/_service \
-                    && ! egrep -q "service .*mode=.(disabled|buildtime|explicit|localonly" \
+                    && ! egrep -q "service .*mode=.(disabled|buildtime|explicit|localonly)" \
                     $TMPDIR/_service; then
                 echo "(W) openSUSE: projects only allow 'disabled', 'buildtime', 'explicit' or 'localonly' services."
             fi


### PR DESCRIPTION
Fixes commit f90d0b9 ("Fix service run mode check for localonly")

Signed-off-by: Olaf Hering <olaf@aepfle.de>