### PR TITLE
Add missing dependency to the debian/control file

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,6 +8,7 @@ Homepage: https://github.com/openSUSE/obs-service-source_validator
 
 Package: obs-service-source-validator
 Architecture: all
+Depends: build | obs-build
 Description: An OBS source service: running all the osc source-validator checks
  This is a source service for openSUSE Build Service.
  .


### PR DESCRIPTION
The helpers/spec_query scripts depends on the build/obs-build package.