### PR TITLE
Spec query use bconf

### DIFF
--- a/70-baselibs
+++ b/70-baselibs
@@ -25,14 +25,11 @@ if [ -e "$DIR_TO_CHECK/_multibuild" ]; then
 	# PASS if we have trouble parsing the .spec file
 	BUILTBINARIES+=($($HELPERS_DIR/spec_query --specfile "$DIR_TO_CHECK"/*.spec --print-subpacks \
 	    --buildflavor $i)) || exit 0
-	BUILTBINARIES+=($($HELPERS_DIR/spec_query --no-conditionals --specfile "$DIR_TO_CHECK"/*.spec --print-subpacks \
-	    --buildflavor $i)) || exit 0
   done
 fi
 for i in "$DIR_TO_CHECK"/*.spec; do
       # PASS if we have trouble parsing the .spec file
       BUILTBINARIES+=($($HELPERS_DIR/spec_query --specfile "$i" --print-subpacks)) || exit 0
-      BUILTBINARIES+=($($HELPERS_DIR/spec_query --no-conditionals --specfile "$i" --print-subpacks)) || exit 0
 done
 
 # add known keywords from baselibs specification

--- a/helpers/spec_query
+++ b/helpers/spec_query
@@ -15,6 +15,7 @@ use Build::Rpm;
 
 our $st_if = 1;
 our $st_ifname = 2;
+our $default_bconf = '/usr/lib/build/configs/sl15.5.conf';
 
 sub prepare_spec {
   my ($fn, $no_conditionals, $keep_name_conditionals, $unique_sources,
@@ -89,11 +90,11 @@ sub prepare_spec {
 }
 
 sub parse {
-  my ($fn, $arch, $no_conditionals, $keep_name_conditionals, $unique_sources,
-      $disambiguate_sources, $buildflavor) = @_;
+  my ($fn, $arch, $bconf, $no_conditionals, $keep_name_conditionals,
+      $unique_sources, $disambiguate_sources, $buildflavor) = @_;
   my $spec = prepare_spec($fn, $no_conditionals, $keep_name_conditionals,
                           $unique_sources, $disambiguate_sources);
-  my $config = Build::read_config($arch, []);
+  my $config = Build::read_config($arch, $bconf);
   $config->{'buildflavor'} = $buildflavor if $buildflavor;
   my $descr = Build::Rpm::parse($config, $spec);
   die("unable to parse specfile: $fn\n") unless $descr;
@@ -125,6 +126,7 @@ Usage: $0 --specfile <specfile> [<options>]
 Options:
   --specfile <specfile>:    the specfile that should be queried
   --arch <arch>:            arch that is used during parsing (default: noarch)
+  --config <config>:        path to a buildconfig (default: $default_bconf)
   --no-conditionals:        do not take %if* conditionals into account during
                             parsing (except if they are used in line
                             continuation contexts)
@@ -143,6 +145,7 @@ EOF
 
 my $specfile;
 my $arch = 'noarch';
+my $bconf = $default_bconf;
 my $print_subpacks;
 my $print_sources;
 my $no_conditionals;
@@ -159,6 +162,8 @@ while (@ARGV) {
   } elsif ($opt eq '--arch') {
     $arch = shift @ARGV;
     usage(1) unless $arch;
+  } elsif ($opt eq '--config') {
+    $bconf = shift @ARGV;
   } elsif ($opt eq '--buildflavor') {
     $buildflavor = shift @ARGV;
   } elsif ($opt eq '--print-subpacks') {
@@ -180,7 +185,8 @@ while (@ARGV) {
   }
 }
 
-my $descr = parse($specfile, $arch, $no_conditionals, $keep_name_conditionals,
-                  $unique_sources, $disambiguate_sources, $buildflavor);
+my $descr = parse($specfile, $arch, $bconf, $no_conditionals,
+                  $keep_name_conditionals, $unique_sources,
+                  $disambiguate_sources, $buildflavor);
 print_subpacks($descr) if $print_subpacks;
 print_sources($descr) if $print_sources;


### PR DESCRIPTION
This fixes the issues mentioned in https://github.com/openSUSE/obs-service-source_validator/commit/1b3d2ee0612d9c1d6849457f8ed441d14e25a4fa#commitcomment-28049342
```
marcus@linux:~/obs-service-source_validator> ./70-baselibs ~/openSUSE\:Factory/glibc/
marcus@linux:~/obs-service-source_validator> ./70-baselibs ~/openSUSE\:Factory/gdb/
marcus@linux:~/obs-service-source_validator> ./70-baselibs ~/openSUSE\:Factory/tevent/
marcus@linux:~/obs-service-source_validator>
```
The question is which buildconfig we should use. For now, we use /usr/lib/build/configs/sl15.5.conf,
but this (of course) has already an outdated suse_version macro (wrt. factory).
Alternatively, we could always fetch the latest factory buildconfig from the obs... (assumptions:
internet access is possible and the source_validator is only used for factory)

@dimstar77, @bugfinder and others: any opinions?:)