### PR TITLE
fix for #bsc985980

### DIFF
--- a/20-files-present-and-referenced
+++ b/20-files-present-and-referenced
@@ -358,7 +358,8 @@ for i in $DIR_TO_CHECK/* $DIR_TO_CHECK/.* ; do
 	debian.*.lintian-overrides )
 	    ;;
 	*)
-            grep -a -x "$BASE" $TMPDIR/sources > /dev/null && continue
+            SEARCHTERM=${BASE//\\/\\\\}
+            grep -a -x "$SEARCHTERM" $TMPDIR/sources > /dev/null && continue
             test -f $DIR_TO_CHECK/_service && egrep -q 'mode=.remoterun' $DIR_TO_CHECK/_service && continue
             # be a bit more relaxed for osc, it won't upload directories anyway
             [ -d "$DIR_TO_CHECK/$BASE" ] && [ -d  $DIR_TO_CHECK/.osc ] && continue

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ test:
 	./helpers/spec_query --no-conditionals --keep-name-conditionals --disambiguate-sources --specfile t/data/cross-aarch64-gcc7.spec
 	./helpers/spec_query --no-conditionals --keep-name-conditionals --disambiguate-sources --specfile t/data/glibc.spec
 	./helpers/spec_query --no-conditionals --keep-name-conditionals --disambiguate-sources --specfile t/data/glibc.spec --buildflavor testsuite
+	./20-files-present-and-referenced t/data/x2d/
 
 
 .PHONY: all install package test

--- a/t/data/x2d/x2d.spec
+++ b/t/data/x2d/x2d.spec
@@ -1,0 +1,1 @@
+Source1:        var-run-vmblock\x2dfuse\x2dnew.mount


### PR DESCRIPTION
This commit fixes the problem mentioned in
https://bugzilla.novell.com/show_bug.cgi?id=985980.
Nowadays only a warning is shown but still if a file contain backslash
like in

var-run-vmblock\x2dfuse.mount

which is a common file name in systemd files

(https://www.freedesktop.org/software/systemd/man/systemd.unit.html)