### PR TITLE
/usr/include/X11 is still a valid path.

### DIFF
--- a/60-spec-filelist
+++ b/60-spec-filelist
@@ -31,7 +31,7 @@ for SPECFILE in $DIR_TO_CHECK/*.spec ; do
               %doc*/*|/*)
                 test $IS_FILE_LIST = true && {
                     case $LINE in
-                      */usr/man/*|*/usr/info/*|*/usr/include/X11/*|*/usr/bin/X11/*)
+                      */usr/man/*|*/usr/info/*|*/usr/bin/X11/*)
                         RETURN=1
                         echo "(E)" `basename $SPECFILE` uses forbidden file path \"$LINE\".
                       ;;


### PR DESCRIPTION
see http://bugzilla.suse.com/show_bug.cgi?id=1098385