### PR TITLE
70-baselibs: do not run subshells

### DIFF
--- a/70-baselibs
+++ b/70-baselibs
@@ -20,14 +20,13 @@ containsElement () {
 
 BUILTBINARIES=()
 if [ -e "$DIR_TO_CHECK/_multibuild" ]; then
-  sed -n -e 's,.*<\(flavor\|package\)>\([^<]*\)</\(flavor\|package\)>.*,\2,p' \
-    "$DIR_TO_CHECK/_multibuild" | while read i; do
-	# PASS if we have trouble parsing the .spec file
-	BUILTBINARIES+=($($HELPERS_DIR/spec_query --specfile "$DIR_TO_CHECK"/*.spec --print-subpacks \
-	    --buildflavor $i)) || exit 0
-	BUILTBINARIES+=($($HELPERS_DIR/spec_query --no-conditionals --specfile "$DIR_TO_CHECK"/*.spec --print-subpacks \
-	    --buildflavor $i)) || exit 0
-  done
+  while read i; do
+    # PASS if we have trouble parsing the .spec file
+    BUILTBINARIES+=($($HELPERS_DIR/spec_query --specfile "$DIR_TO_CHECK"/*.spec --print-subpacks \
+      --buildflavor $i)) || exit 0
+    BUILTBINARIES+=($($HELPERS_DIR/spec_query --no-conditionals --specfile "$DIR_TO_CHECK"/*.spec --print-subpacks \
+      --buildflavor $i)) || exit 0
+  done < <(sed -n -e 's,.*<\(flavor\|package\)>\([^<]*\)</\(flavor\|package\)>.*,\2,p' "$DIR_TO_CHECK/_multibuild")
 fi
 for i in "$DIR_TO_CHECK"/*.spec; do
       # PASS if we have trouble parsing the .spec file


### PR DESCRIPTION
the method

```sed … |while read i; do```technically works, but as this is run inside a subshell, the variable BUILTBINARIES is local to the subshell and not being filled for later consumption. As such, any RPM built as part of a flavor is not identified