### PR TITLE
One .changes file per package is enough

### DIFF
--- a/45-stale-changes
+++ b/45-stale-changes
@@ -40,11 +40,12 @@ for i in $SPECLIST ; do
         *-) i=${i}MACRO ; DO_PASS="1"
         ;;
     esac
-    test -f $DIR_TO_CHECK/$i.changes -o "$DO_PASS" = "1" || {
-	echo "WARNING: $i.changes does not exist. This package can not be submitted to openSUSE product projects."
-	exit 0
-    }
+    test -f $DIR_TO_CHECK/$i.changes && DO_PASS=1
 done
+test "$DO_PASS" = "1" || {
+    echo "WARNING: No .changes file found. This package can not be submitted to openSUSE product projects."
+    exit 0
+}
 # check for stale .changes files
 for i in $DIR_TO_CHECK/*.changes ; do
     test -f $i || continue


### PR DESCRIPTION
It's actually fine to have a single .changes file for multiple .spec files
in the same package, OBS picks that automatically. Relax the check to only
require a single .changes file.

Many multi-spec packages currently just duplicate the changes files anyway,
which can be avoided.