### PR TITLE
Fix warnings printed when validating openSUSE-MicroOS

### DIFF
--- a/45-stale-changes
+++ b/45-stale-changes
@@ -20,6 +20,7 @@ test -f "$DIR_TO_CHECK/_service" && egrep -q 'name=.product_converter' "$DIR_TO_
 
 print_specs () {
 for i in "$DIR_TO_CHECK"/*.spec; do
+  [ -e "$i" ] || return
   # PASS if we have trouble parsing the .spec file
   if [ -e "$DIR_TO_CHECK/_multibuild" ]; then
     sed -n -e 's,.*<\(flavor\|package\)>\([^<]*\)</\(flavor\|package\)>.*,\2,p' \

--- a/45-stale-changes
+++ b/45-stale-changes
@@ -23,8 +23,7 @@ for i in "$DIR_TO_CHECK"/*.spec; do
   [ -e "$i" ] || return
   # PASS if we have trouble parsing the .spec file
   if [ -e "$DIR_TO_CHECK/_multibuild" ]; then
-    sed -n -e 's,.*<\(flavor\|package\)>\([^<]*\)</\(flavor\|package\)>.*,\2,p' \
-      "$DIR_TO_CHECK/_multibuild" | while read flavor; do
+    xmllint -xpath '/multibuild/flavor/text()' "$DIR_TO_CHECK/_multibuild" | while read flavor; do
         $HELPERS_DIR/spec_query --specfile "$i" --print-subpacks --buildflavor $flavor | sed -e "s@ .*@@"
     done
   fi


### PR DESCRIPTION
openSUSE-MicroOS ran into two issues. The `_multibuild` file had a comment which confused the "sed XML parser". It also doesn't have a .spec file.

This lead to warning spam and wasted time:

```
/data/obs/devel:kubic:images/openSUSE-MicroOS/*.spec: No such file or directory
/data/obs/devel:kubic:images/openSUSE-MicroOS/*.spec: No such file or directory
/data/obs/devel:kubic:images/openSUSE-MicroOS/*.spec: No such file or directory
/data/obs/devel:kubic:images/openSUSE-MicroOS/*.spec: No such file or directory
...
```