### PR TITLE
45-stale-changes: Also read <package/> in _multibuild

### DIFF
--- a/45-stale-changes
+++ b/45-stale-changes
@@ -23,7 +23,7 @@ for i in "$DIR_TO_CHECK"/*.spec; do
   [ -e "$i" ] || return
   # PASS if we have trouble parsing the .spec file
   if [ -e "$DIR_TO_CHECK/_multibuild" ]; then
-    xmllint -xpath '/multibuild/flavor/text()' "$DIR_TO_CHECK/_multibuild" | while read flavor; do
+    xmllint -xpath '(/multibuild/flavor | /multibuild/package)/text()' "$DIR_TO_CHECK/_multibuild" | while read flavor; do
         $HELPERS_DIR/spec_query --specfile "$i" --print-subpacks --buildflavor $flavor | sed -e "s@ .*@@"
     done
   fi


### PR DESCRIPTION
It was missing handling for `<package/>` next to `<flavor/>` tags.

For `_multibuild` files which just used `<package>foo</package>` it printed `XPath set is empty`.