### PR TITLE
spec_query: add elif support

### DIFF
--- a/helpers/spec_query
+++ b/helpers/spec_query
@@ -43,6 +43,9 @@ sub prepare_spec {
     } elsif (/^\s*%if/) {
       unshift @ifs, { $st_if => $line };
       next;
+    } elsif (/^\s*%elif/) {
+      die($line . ": %elif without %if\n") unless @ifs;
+      next;
     } elsif (/^\s*%else/) {
       die($line . ": %else without %if\n") unless @ifs;
       if (exists $ifs[0]{$st_ifname}) {


### PR DESCRIPTION
rpm 4.15 and above has support for %elif which is a handy shortcut for
%else/%if + %endif combinations.

  %if "%{x}" == "a"
  %else
  %if "%{x}" == "b"
  %endif
  %endif

can be rewritten into

  %if "%{x}" == "a"
  %elif "%{x}" == "b"
  %endif

Add minimal support by just skipping over it.