### PR TITLE
Accept 'manual' mode in _service

### DIFF
--- a/20-files-present-and-referenced
+++ b/20-files-present-and-referenced
@@ -116,9 +116,9 @@ if [ -x $(type -p xmllint) ]; then
             xmllint --format "$i" > $TMPDIR/_service
 
             if egrep -q "service .*mode=." $TMPDIR/_service \
-                    && ! egrep -q "service .*mode=.(disabled|buildtime|explicit|localonly)" \
+                    && ! egrep -q "service .*mode=.(disabled|buildtime|manual|localonly)" \
                     $TMPDIR/_service; then
-                echo "(W) openSUSE: projects only allow 'disabled', 'buildtime', 'explicit' or 'localonly' services."
+                echo "(W) openSUSE: projects only allow 'disabled', 'buildtime', 'manual' or 'localonly' services."
             fi
         fi
 


### PR DESCRIPTION
According to
https://openbuildservice.org/help/manuals/obs-user-guide/cha.obs.source_service.html#id-1.5.8.4.4.3
there is no "explicit" mode. Only a "manual" one.