### PR TITLE
Allow mode=manual services

### DIFF
--- a/20-files-present-and-referenced
+++ b/20-files-present-and-referenced
@@ -116,9 +116,9 @@ if [ -x $(type -p xmllint) ]; then
             xmllint --format "$i" > $TMPDIR/_service
 
             if egrep -q "service .*mode=." $TMPDIR/_service \
-                    && ! egrep -q "service .*mode=.(disabled|buildtime|explicit|localonly)" \
+                    && ! egrep -q "service .*mode=.(disabled|manual|buildtime|localonly)" \
                     $TMPDIR/_service; then
-                echo "(W) openSUSE: projects only allow 'disabled', 'buildtime', 'explicit' or 'localonly' services."
+                echo "(W) openSUSE: projects only allow 'manual' or 'buildtime' services (localonly/disabled are deprecated)."
             fi
         fi
 


### PR DESCRIPTION
manual is the new name of disabled, see https://github.com/openSUSE/osc/pull/826
Stop advertising deprecated names, so shorten warning message.

Remove explicit as the api does not allow that:
https://github.com/openSUSE/open-build-service/blob/4a4d5b0f07dd0d6bc03def3e863d299bfebcd7ad/docs/api/api/obs.rng#L88-L96