### PR TITLE
Treat to-be-deleted patches as nonexisting for the source-tracked check

### DIFF
--- a/20-files-present-and-referenced
+++ b/20-files-present-and-referenced
@@ -127,30 +127,30 @@ fi
 
 check_tracked()
 {
-	local file=${1##*/}
+    local file=${1##*/}
 
-	if test "$OSC_MODE" = "true" ; then
-		if test -f "$DESTINATIONDIR/$file"; then
-			return 0
-		fi
-	        if test -f "$DESTINATIONDIR/${file/\.tar*/}.obscpio"; then
-			# assume it will generated on builtime based of the archive
-			return 0
-		fi
-		if grep -qsFx "$file" "$DESTINATIONDIR/_to_be_added"; then
-			return 0
-		fi
-		echo "ERROR: $file mentioned in spec file is not tracked."
-		return 1
-	fi
-	if ! test -f "$DIR_TO_CHECK/$file"; then
-	        if test -f "$DIR_TO_CHECK/${file/\.tar*/}.obscpio"; then
-			# assume it will generated on builtime based of the archive
-			return 0
-		fi
-		echo "ERROR: $file mentioned in spec file does not exist."
-		return 1
-	fi
+    if test "$OSC_MODE" = "true" ; then
+        if test -f "$DESTINATIONDIR/$file" && ! grep -qsFx "$file" "$DESTINATIONDIR/_to_be_deleted"; then
+            return 0
+        fi
+        if test -f "$DESTINATIONDIR/${file/\.tar*/}.obscpio"; then
+            # assume it will generated on builtime based of the archive
+            return 0
+        fi
+        if grep -qsFx "$file" "$DESTINATIONDIR/_to_be_added"; then
+            return 0
+        fi
+        echo "ERROR: $file mentioned in spec file is not tracked."
+        return 1
+    fi
+    if ! test -f "$DIR_TO_CHECK/$file"; then
+        if test -f "$DIR_TO_CHECK/${file/\.tar*/}.obscpio"; then
+            # assume it will generated on builtime based of the archive
+            return 0
+        fi
+        echo "ERROR: $file mentioned in spec file does not exist."
+        return 1
+    fi
 }
 
 if ! test -f "$DIR_TO_CHECK/_service"; then


### PR DESCRIPTION
When a patch is about to be deleted, we should already point out
that it isn't there, so that missing .spec file source references
are reported properly.