### PR TITLE
Convert all egrep/fgrep calls to grep -E/-F, respectively.

### DIFF
--- a/20-files-present-and-referenced
+++ b/20-files-present-and-referenced
@@ -115,8 +115,8 @@ if [ -x $(type -p xmllint) ]; then
         if [ "$BASE" = "_service" ]; then
             xmllint --format "$i" > $TMPDIR/_service
 
-            if egrep -q "service .*mode=." $TMPDIR/_service \
-                    && ! egrep -q "service .*mode=.(disabled|manual|buildtime|localonly)" \
+            if grep -E -q "service .*mode=." $TMPDIR/_service \
+                    && ! grep -E -q "service .*mode=.(disabled|manual|buildtime|localonly)" \
                     $TMPDIR/_service; then
                 echo "(W) openSUSE: projects only allow 'manual' or 'buildtime' services (localonly/disabled are deprecated)."
             fi
@@ -263,7 +263,7 @@ for i in "$DIR_TO_CHECK"/* "$DIR_TO_CHECK"/.* ; do
             warn_on_unmentioned_files $BASE
 
 
-	    LINE=$(egrep "^[^#]*setBadness" "$DIR_TO_CHECK/$BASE")
+	    LINE=$(grep -E "^[^#]*setBadness" "$DIR_TO_CHECK/$BASE")
 	    if [ "$LINE" != "" ]; then
 	        if test "$BATCHMODE" != true ; then
 		    echo "ERROR: Found possibly illegal rpmlintrc line:"
@@ -346,8 +346,8 @@ for i in "$DIR_TO_CHECK"/* "$DIR_TO_CHECK"/.* ; do
 	*)
             SEARCHTERM=${BASE//\\/\\\\}
             grep -a -x "$SEARCHTERM" $TMPDIR/sources > /dev/null && continue
-            test -f "$DIR_TO_CHECK/_service" && egrep -q 'mode=.remoterun' "$DIR_TO_CHECK/_service" && continue
-            test -f "$DIR_TO_CHECK/_service" && egrep -q 'name=.product_converter' "$DIR_TO_CHECK/_service" && continue
+            test -f "$DIR_TO_CHECK/_service" && grep -E -q 'mode=.remoterun' "$DIR_TO_CHECK/_service" && continue
+            test -f "$DIR_TO_CHECK/_service" && grep -E -q 'name=.product_converter' "$DIR_TO_CHECK/_service" && continue
             # be a bit more relaxed for osc, it won't upload directories anyway
             [ -d "$DIR_TO_CHECK/$BASE" ] && [ -d  "$DIR_TO_CHECK/.osc" ] && continue
             # and source services on server side

--- a/45-stale-changes
+++ b/45-stale-changes
@@ -13,7 +13,7 @@ test -z "$DESTINATIONDIR" -a -d "$DIR_TO_CHECK/.osc" && DESTINATIONDIR="$DIR_TO_
 RETURN=0
 test "$VERBOSE" = true && echo -n "- checking for stale or missing changes "
 
-test -f "$DIR_TO_CHECK/_service" && egrep -q 'name=.product_converter' "$DIR_TO_CHECK/_service" && {
+test -f "$DIR_TO_CHECK/_service" && grep -E -q 'name=.product_converter' "$DIR_TO_CHECK/_service" && {
     test "$VERBOSE" = true && echo skipped for product
     exit 0
 }

--- a/t/data/python-libmount.spec
+++ b/t/data/python-libmount.spec
@@ -440,7 +440,7 @@ make %{?_smp_mflags} setctsid CFLAGS="%{optflags}" CC="%{__cc}"
 #
 # WARNING: Never edit following line without doing all suggested in the echo below!
 UTIL_LINUX_KNOWN_SYSTEMD_DEPS='./login-utils/lslogins.c ./misc-utils/logger.c ./misc-utils/uuidd.c '
-UTIL_LINUX_FOUND_SYSTEMD_DEPS=$(grep -rl 'HAVE_LIBSYSTEMD' . | fgrep '.c' | LC_ALL=C sort | tr '\n' ' ')
+UTIL_LINUX_FOUND_SYSTEMD_DEPS=$(grep -rl 'HAVE_LIBSYSTEMD' . | grep -F '.c' | LC_ALL=C sort | tr '\n' ' ')
 if test "$UTIL_LINUX_KNOWN_SYSTEMD_DEPS" != "$UTIL_LINUX_FOUND_SYSTEMD_DEPS" ; then
 	echo "List of utilities depending on systemd have changed.
 Please check the new util-linux-systemd file list, file removal and update of Conflicts for safe update!

--- a/t/data/util-linux-systemd.spec
+++ b/t/data/util-linux-systemd.spec
@@ -440,7 +440,7 @@ make %{?_smp_mflags} setctsid CFLAGS="%{optflags}" CC="%{__cc}"
 #
 # WARNING: Never edit following line without doing all suggested in the echo below!
 UTIL_LINUX_KNOWN_SYSTEMD_DEPS='./login-utils/lslogins.c ./misc-utils/logger.c ./misc-utils/uuidd.c '
-UTIL_LINUX_FOUND_SYSTEMD_DEPS=$(grep -rl 'HAVE_LIBSYSTEMD' . | fgrep '.c' | LC_ALL=C sort | tr '\n' ' ')
+UTIL_LINUX_FOUND_SYSTEMD_DEPS=$(grep -rl 'HAVE_LIBSYSTEMD' . | grep -F '.c' | LC_ALL=C sort | tr '\n' ' ')
 if test "$UTIL_LINUX_KNOWN_SYSTEMD_DEPS" != "$UTIL_LINUX_FOUND_SYSTEMD_DEPS" ; then
 	echo "List of utilities depending on systemd have changed.
 Please check the new util-linux-systemd file list, file removal and update of Conflicts for safe update!

--- a/t/data/util-linux.spec
+++ b/t/data/util-linux.spec
@@ -440,7 +440,7 @@ make %{?_smp_mflags} setctsid CFLAGS="%{optflags}" CC="%{__cc}"
 #
 # WARNING: Never edit following line without doing all suggested in the echo below!
 UTIL_LINUX_KNOWN_SYSTEMD_DEPS='./login-utils/lslogins.c ./misc-utils/logger.c ./misc-utils/uuidd.c '
-UTIL_LINUX_FOUND_SYSTEMD_DEPS=$(grep -rl 'HAVE_LIBSYSTEMD' . | fgrep '.c' | LC_ALL=C sort | tr '\n' ' ')
+UTIL_LINUX_FOUND_SYSTEMD_DEPS=$(grep -rl 'HAVE_LIBSYSTEMD' . | grep -F '.c' | LC_ALL=C sort | tr '\n' ' ')
 if test "$UTIL_LINUX_KNOWN_SYSTEMD_DEPS" != "$UTIL_LINUX_FOUND_SYSTEMD_DEPS" ; then
 	echo "List of utilities depending on systemd have changed.
 Please check the new util-linux-systemd file list, file removal and update of Conflicts for safe update!


### PR DESCRIPTION
grep 3.8 starts throwing warnings, and `egrep`/`fgrep` will be dropped long term
https://bugzilla.opensuse.org/show_bug.cgi?id=1203092