### PR TITLE
Do not check for all _multibuild flavors if spec does not conitionalize on BUILD_FLAVOR

### DIFF
--- a/20-files-present-and-referenced
+++ b/20-files-present-and-referenced
@@ -55,7 +55,7 @@ esac
 
 for i in "$DIR_TO_CHECK"/*.spec ; do
         test -f "$i" || continue
-        if [ -e "$DIR_TO_CHECK/_multibuild" ]; then
+        if [ -e "$DIR_TO_CHECK/_multibuild" ] && grep -q "@BUILD_FLAVOR@" "$i"; then
           sed -n -e 's,.*<\(flavor\|package\)>\([^<]*\)</\(flavor\|package\)>.*,\2,p' \
               "$DIR_TO_CHECK/_multibuild" | while read flavor; do
 	    $HELPERS_DIR/spec_query --specfile "$i" --print-sources --buildflavor "$flavor"\

--- a/45-stale-changes
+++ b/45-stale-changes
@@ -22,7 +22,7 @@ print_specs () {
 for i in "$DIR_TO_CHECK"/*.spec; do
   [ -e "$i" ] || return
   # PASS if we have trouble parsing the .spec file
-  if [ -e "$DIR_TO_CHECK/_multibuild" ]; then
+  if [ -e "$DIR_TO_CHECK/_multibuild" ] && grep -q "@BUILD_FLAVOR@" "$i"; then
     xmllint -xpath '(/multibuild/flavor | /multibuild/package)/text()' "$DIR_TO_CHECK/_multibuild" | while read flavor; do
         $HELPERS_DIR/spec_query --specfile "$i" --print-subpacks --buildflavor $flavor | sed -e "s@ .*@@"
     done


### PR DESCRIPTION
_multibuild can be used so instruct OBS to build multiple spec files inside a package container
or to inject build_flavors into spec files. One can use either multiple spec files or build_flavors, but
not the combination.

Fixes issue #103 
