### PR TITLE
Unify _multibuild handling and do it like OBS

### DIFF
--- a/20-files-present-and-referenced
+++ b/20-files-present-and-referenced
@@ -10,6 +10,7 @@ BASE_DIR=$(dirname $0)
 BASE_DIR=${BASE_DIR:-.}
 HELPERS_DIR="$BASE_DIR/helpers"
 $HELPERS_DIR/check_input_filename "$DIR_TO_CHECK" || exit 1
+. $HELPERS_DIR/functions
 test -z "$DESTINATIONDIR" -a -d "$DIR_TO_CHECK/.osc" && {
 	DESTINATIONDIR="$DIR_TO_CHECK/.osc"
 	OSC_MODE="true"
@@ -53,19 +54,10 @@ case $MY_ARCH in
     ;;
 esac
 
-for i in "$DIR_TO_CHECK"/*.spec ; do
-        test -f "$i" || continue
-        if [ -e "$DIR_TO_CHECK/_multibuild" ] && grep -q "@BUILD_FLAVOR@" "$i"; then
-          sed -n -e 's,.*<\(flavor\|package\)>\([^<]*\)</\(flavor\|package\)>.*,\2,p' \
-              "$DIR_TO_CHECK/_multibuild" | while read flavor; do
-	    $HELPERS_DIR/spec_query --specfile "$i" --print-sources --buildflavor "$flavor"\
-               --no-conditionals --keep-name-conditionals --disambiguate-sources \
-               >> "$TMPDIR/sources" 2>"$TMPDIR/sources.err"
-          done
-        fi
-  	$HELPERS_DIR/spec_query --specfile "$i" --print-sources \
-            --no-conditionals --keep-name-conditionals --disambiguate-sources \
-            >> "$TMPDIR/sources" 2>"$TMPDIR/sources.err"
+while read recipe flavor; do
+	$HELPERS_DIR/spec_query --specfile "${DIR_TO_CHECK}/${recipe}" --print-sources --buildflavor "$flavor" \
+	--no-conditionals --keep-name-conditionals --disambiguate-sources \
+        >> "$TMPDIR/sources" 2>"$TMPDIR/sources.err"
         # ignore expand errors with macro scripts
 	sed -i "/can't expand %(...)/d" "$TMPDIR/sources.err"
 	# ignore macro nesting reported by build script
@@ -75,7 +67,7 @@ for i in "$DIR_TO_CHECK"/*.spec ; do
 	    cat "$TMPDIR/sources.err"
 	    cleanup_and_exit 1
 	fi
-done
+done < <(spec_build_flavors "$DIR_TO_CHECK")
 for i in "$DIR_TO_CHECK"/*.dsc ; do
 	test -f "$i" || continue
 	( sed -ne '/^Files:/,$p' < "$i" | sed -e 1d | sed -e '/^[^ ]/,$d' | while read debchk debsize debfile ; do echo "$debfile" ; done ) >> $TMPDIR/sources

--- a/45-stale-changes
+++ b/45-stale-changes
@@ -7,7 +7,7 @@ DESTINATIONDIR="$2"
 test -n "$DIR_TO_CHECK" || DIR_TO_CHECK=`pwd`
 HELPERS_DIR="/usr/lib/obs/service/source_validators/helpers"
 $HELPERS_DIR/check_input_filename "$DIR_TO_CHECK" || exit 1
-
+. $HELPERS_DIR/functions
 test -z "$DESTINATIONDIR" -a -d "$DIR_TO_CHECK/.osc" && DESTINATIONDIR="$DIR_TO_CHECK/.osc"
 
 RETURN=0
@@ -19,16 +19,9 @@ test -f "$DIR_TO_CHECK/_service" && grep -E -q 'name=.product_converter' "$DIR_T
 }
 
 print_specs () {
-for i in "$DIR_TO_CHECK"/*.spec; do
-  [ -e "$i" ] || return
-  # PASS if we have trouble parsing the .spec file
-  if [ -e "$DIR_TO_CHECK/_multibuild" ] && grep -q "@BUILD_FLAVOR@" "$i"; then
-    xmllint -xpath '(/multibuild/flavor | /multibuild/package)/text()' "$DIR_TO_CHECK/_multibuild" | while read flavor; do
-        $HELPERS_DIR/spec_query --specfile "$i" --print-subpacks --buildflavor $flavor | sed -e "s@ .*@@"
-    done
-  fi
-  $HELPERS_DIR/spec_query --specfile "$i" --print-subpacks | sed -e "s@ .*@@"
-done
+while read recipe flavor; do
+  $HELPERS_DIR/spec_query --specfile "${DIR_TO_CHECK}/${recipe}" --print-subpacks --buildflavor "$flavor" | sed -e "s@ .*@@"
+done < <(spec_build_flavors "$DIR_TO_CHECK")
 }
 
 SPECLIST=`print_specs | sort -u`

--- a/70-baselibs
+++ b/70-baselibs
@@ -7,6 +7,7 @@ DESTINATIONDIR="$2"
 test -n "$DIR_TO_CHECK" || DIR_TO_CHECK=`pwd`
 HELPERS_DIR="/usr/lib/obs/service/source_validators/helpers"
 $HELPERS_DIR/check_input_filename "$DIR_TO_CHECK" || exit 1
+. $HELPERS_DIR/functions
 test -z "$DESTINATIONDIR" -a -d "$DIR_TO_CHECK/.osc" && DESTINATIONDIR="$DIR_TO_CHECK/.osc"
 
 containsElement () {
@@ -19,20 +20,12 @@ containsElement () {
 [ -f "$DIR_TO_CHECK/baselibs.conf" ] || exit 0
 
 BUILTBINARIES=()
-if [ -e "$DIR_TO_CHECK/_multibuild" ]; then
-  while read i; do
-    # PASS if we have trouble parsing the .spec file
-    BUILTBINARIES+=($($HELPERS_DIR/spec_query --specfile "$DIR_TO_CHECK"/*.spec --print-subpacks \
-      --buildflavor "$i")) || exit 0
-    BUILTBINARIES+=($($HELPERS_DIR/spec_query --no-conditionals --specfile "$DIR_TO_CHECK"/*.spec --print-subpacks \
-      --buildflavor "$i")) || exit 0
-  done < <(sed -n -e 's,.*<\(flavor\|package\)>\([^<]*\)</\(flavor\|package\)>.*,\2,p' "$DIR_TO_CHECK/_multibuild")
-fi
-for i in "$DIR_TO_CHECK"/*.spec; do
-      # PASS if we have trouble parsing the .spec file
-      BUILTBINARIES+=($($HELPERS_DIR/spec_query --specfile "$i" --print-subpacks)) || exit 0
-      BUILTBINARIES+=($($HELPERS_DIR/spec_query --no-conditionals --specfile "$i" --print-subpacks)) || exit 0
-done
+while read recipe flavor; do
+	BUILTBINARIES+=($($HELPERS_DIR/spec_query --specfile "${DIR_TO_CHECK}/${recipe}" --print-subpacks \
+	--buildflavor "$flavor")) || exit 0
+	BUILTBINARIES+=($($HELPERS_DIR/spec_query --specfile "${DIR_TO_CHECK}/${recipe}" --print-subpacks \
+	--buildflavor "$flavor" --no-conditionals)) || exit 0
+done < <(spec_build_flavors "$DIR_TO_CHECK")
 
 # add known keywords from baselibs specification
 BUILTBINARIES+=('arch' 'targetname' 'targettype')

--- a/helpers/functions
+++ b/helpers/functions
@@ -1,0 +1,32 @@
+# Utility functions shared by some validator shell scripts
+
+# Returns a list of build flavors in the form "pkg1.spec\npkg2.spec", "package.spec foo\npackage.spec bar",
+# for easy consumption by a "while read recipe flavor" loop.
+# First argument is the source directory.
+spec_build_flavors() {
+	pushd "$1" >/dev/null
+	if ! [ -e "_multibuild" ]; then
+		for i in *.spec; do
+			echo "$i"
+		done
+	else
+		pkg="$(basename "$PWD")"
+		if [ -e "${pkg}.spec" ]; then
+			echo "${pkg}.spec"
+		fi
+
+		xmllint -xpath '(/multibuild/flavor | /multibuild/package)/text()' _multibuild | while read flavor; do
+			if [ -e "${flavor}.spec" ]; then
+				echo "${flavor}.spec $flavor"
+				continue
+			fi
+
+			specs=(*.spec)
+			if [ "${#specs[@]}" -eq 1 ] && [ -e "${specs[0]}" ]; then
+				# Exactly one .spec file
+				echo "${specs[0]} $flavor"
+			fi
+		done
+	fi
+	popd >/dev/null
+}


### PR DESCRIPTION
Currently several validators handle _multibuild files and they all do it differently. On top of that, they all had different behaviour than OBS. Introduce a simple helper function that does it properly and use it in all validators.