### PR TITLE
Fix handling of packages with neither *.spec nor _multibuild

### DIFF
--- a/helpers/functions
+++ b/helpers/functions
@@ -7,7 +7,7 @@ spec_build_flavors() {
 	pushd "$1" >/dev/null
 	if ! [ -e "_multibuild" ]; then
 		for i in *.spec; do
-			echo "$i"
+			[ -e "$i" ] && echo "$i"
 		done
 	else
 		pkg="$(basename "$PWD")"


### PR DESCRIPTION
nullglob is disabled, so it tried to read the file '*.spec' if there is no .spec file in the directory.