### PR TITLE
20-files-present-and-referenced: Check for files in *.obscpio + bonus fix

### DIFF
--- a/20-files-present-and-referenced
+++ b/20-files-present-and-referenced
@@ -154,7 +154,7 @@ fi
 # Check for empty or ill-formatted patches
 
 for f in $(<$TMPDIR/sources); do
-    if test ! -f "$DIR_TO_CHECK/$file"; then
+    if test ! -f "$DIR_TO_CHECK/$f"; then
         continue
     fi
     case $f in

--- a/20-files-present-and-referenced
+++ b/20-files-present-and-referenced
@@ -117,6 +117,20 @@ if [ -x $(type -p xmllint) ]; then
     done
 fi
 
+obscpio_file_list()
+{
+    if ! [ -e "$TMPDIR/obcspio_sources" ]; then
+        touch "$TMPDIR/obcspio_sources"
+        for i in "$DIR_TO_CHECK/"*.obscpio; do
+            if [ -e "$i" ]; then
+                cpio --list --quiet < "$i" >> "$TMPDIR/obcspio_sources"
+            fi
+        done
+    fi
+
+    cat "$TMPDIR/obcspio_sources"
+}
+
 check_tracked()
 {
     local file=${1##*/}
@@ -132,12 +146,18 @@ check_tracked()
         if grep -qsFx "$file" "$DESTINATIONDIR/_to_be_added"; then
             return 0
         fi
+        if obscpio_file_list | grep -qFx "$file"; then
+            return 0
+        fi
         echo "ERROR: $file mentioned in spec file is not tracked."
         return 1
     fi
     if ! test -f "$DIR_TO_CHECK/$file"; then
         if test -f "$DIR_TO_CHECK/${file/\.tar*/}.obscpio"; then
             # assume it will generated on builtime based of the archive
+            return 0
+        fi
+        if obscpio_file_list | grep -qFx "$file"; then
             return 0
         fi
         echo "ERROR: $file mentioned in spec file does not exist."


### PR DESCRIPTION
.obscpio files are extracted before build and the contents can be used as
sources. This is not the only use case for obscpio though: most of the time
they carry the (large) source code, which is converted to a tarball by a
buildtime service. We can't easily tell those cases apart, so just don't
bother.

It would be possible to avoid false negatives here by checking against the cpio listing as fallback, but that might take very long for larger .obscpio archives containing source code.