### PR TITLE
helpers/functions: Always treat all *.spec files as recipes

### DIFF
--- a/helpers/functions
+++ b/helpers/functions
@@ -5,16 +5,11 @@
 # First argument is the source directory.
 spec_build_flavors() {
 	pushd "$1" >/dev/null
-	if ! [ -e "_multibuild" ]; then
-		for i in *.spec; do
-			[ -e "$i" ] && echo "$i"
-		done
-	else
-		pkg="$(basename "$PWD")"
-		if [ -e "${pkg}.spec" ]; then
-			echo "${pkg}.spec"
-		fi
+	for i in *.spec; do
+		[ -e "$i" ] && echo "$i"
+	done
 
+	if [ -e "_multibuild" ]; then
 		xmllint -xpath '(/multibuild/flavor | /multibuild/package)/text()' _multibuild | while read flavor; do
 			if [ -e "${flavor}.spec" ]; then
 				echo "${flavor}.spec $flavor"


### PR DESCRIPTION
If multiple .spec files are present, OBS builds only the one which matches the source container name. It's not possible to reliably tell what that will be, so just use all options.

(Better?) alternative to #128 