### PR TITLE
helpers/check_patches_applied: Fix detection of applying nonexisting patches

### DIFF
--- a/helpers/check_patches_applied
+++ b/helpers/check_patches_applied
@@ -114,10 +114,9 @@ for my $i (0...$#PATCHES) {
 	print STDERR "${col_red}ERROR: $filename: patch $i $PATCHES[$i] apparently not applied (or not applied via %patch)$col_norm\n";
 	$errors++;
 }
-for my $j (1...$#APPLIED) {
-	next unless $APPLIED[$j];
-	next if $APPLIED[$j];
-	next if $PATCHES[$j] == 2;
+for my $j (0...$#APPLIED) {
+	next unless $APPLIED[$j] && $APPLIED[$j] == 1;
+	next if $PATCHES[$j] && !$PATCHES_COMMENTED[$j];
 	print STDERR "${col_red}ERROR: $filename: patch number $j referenced but not defined$col_norm\n";
 	$errors++;
 }


### PR DESCRIPTION
Depends on #137 

- Numbers start at 0
- Make the code no longer unreachable
- Complain if a commented patch is applied