### PR TITLE
Report error about future timestamps

### DIFF
--- a/helpers/changelogfilter
+++ b/helpers/changelogfilter
@@ -8,6 +8,7 @@ use Time::Zone;
 
 use strict;
 
+$ENV{TZ} = "UTC";
 my @wday = qw{Sun Mon Tue Wed Thu Fri Sat};
 my @mon = qw{Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec};
 my $zone;

--- a/helpers/check_dates_in_changes
+++ b/helpers/check_dates_in_changes
@@ -13,6 +13,7 @@ if [ X"$1" = X"" ]; then
     usage 1
 fi
 
+now=`date +%s`
 for CHANGES in "$@" ; do
 
     TROUBLE_FOUND=false
@@ -46,7 +47,6 @@ for CHANGES in "$@" ; do
             done
 			case $DATESTR in
 				\ [MTWFS][a-z][a-z]*)
-				break
 				;;
 				*)
 				echo "ERROR: '$DATESTR' is not a date"
@@ -54,9 +54,9 @@ for CHANGES in "$@" ; do
 				;;
 			esac
             DATE=`date +%s --date "$DATESTR" 2> /dev/null`
-            test $? -gt 0 -o -z "$DATE" -o "$LAST_IS_YEAR" != true && {
+            test $? -gt 0 -o -z "$DATE" -o "$LAST_IS_YEAR" != true -o "$DATE" -gt "$now" && {
                 echo "$CHANGES"
-                echo "ERROR: INVALID \"$DATESTR\" "
+                echo "ERROR: INVALID DATE \"$DATESTR\" "
                 TROUBLE_FOUND=true
             }
           ;;


### PR DESCRIPTION
Report error about future timestamps
    
The latest `.changes` entry is used for `SOURCE_DATE_EPOCH`,
which is expected to always be in the past for mtime-clamping to work.
    
Note that the `break` had to be dropped, because it skipped the other checks
if the line started with a day-of-week (e.g. Sun)
