### PR TITLE
Being able to handle git managed sources

### DIFF
--- a/20-files-present-and-referenced
+++ b/20-files-present-and-referenced
@@ -12,20 +12,24 @@ HELPERS_DIR="$BASE_DIR/helpers"
 $HELPERS_DIR/check_input_filename "$DIR_TO_CHECK" || exit 1
 . $HELPERS_DIR/functions
 test -z "$DESTINATIONDIR" -a -d "$DIR_TO_CHECK/.osc" && {
-	OSCLIBVER="$(<.osc/_osclib_version)"
-	case "$OSCLIBVER" in
-	  1.0)
-	    DESTINATIONDIR="$DIR_TO_CHECK/.osc"
-	    DOTOSCDIR="$DIR_TO_CHECK/.osc"
-	    ;;
-	  2.0)
-	    DESTINATIONDIR="$DIR_TO_CHECK/.osc/sources"
-	    DOTOSCDIR="$DIR_TO_CHECK/.osc"
-	    ;;
-	  *)
-	    echo "osclib version $OSCLIBVER not yet supported by source_validator" && exit 2
-	    ;;
-	esac
+	if [ -d "$DIR_TO_CHECK/.git" ]; then
+            DESTINATIONDIR="$DIR_TO_CHECK"
+	else
+            OSCLIBVER="$(<.osc/_osclib_version)"
+            case "$OSCLIBVER" in
+              1.0)
+                DESTINATIONDIR="$DIR_TO_CHECK/.osc"
+                DOTOSCDIR="$DIR_TO_CHECK/.osc"
+                ;;
+              2.0)
+                DESTINATIONDIR="$DIR_TO_CHECK/.osc/sources"
+                DOTOSCDIR="$DIR_TO_CHECK/.osc"
+                ;;
+              *)
+                echo "osclib version $OSCLIBVER not yet supported by source_validator" && exit 2
+                ;;
+            esac
+	fi
 	OSC_MODE="true"
 }
 
@@ -80,6 +84,10 @@ while read recipe flavor; do
 	    cat "$TMPDIR/sources.err"
 	    cleanup_and_exit 1
 	fi
+	$HELPERS_DIR/spec_query --specfile "${DIR_TO_CHECK}/${recipe}" --print-moveassets --buildflavor "$flavor" \
+	--no-conditionals --keep-name-conditionals --disambiguate-sources \
+        | sed 's,^.*/,,' \
+        >> "$TMPDIR/moveassettargets" 2>"$TMPDIR/sources.err"
 done < <(spec_build_flavors "$DIR_TO_CHECK")
 for i in "$DIR_TO_CHECK"/*.dsc ; do
 	test -f "$i" || continue
@@ -132,22 +140,30 @@ fi
 
 obscpio_file_list()
 {
-    if ! [ -e "$TMPDIR/obcspio_sources" ]; then
-        touch "$TMPDIR/obcspio_sources"
+    if ! [ -e "$TMPDIR/obscpio_sources" ]; then
+        touch "$TMPDIR/obscpio_sources"
         for i in "$DIR_TO_CHECK/"*.obscpio; do
             if [ -e "$i" ]; then
-                cpio --list --quiet < "$i" >> "$TMPDIR/obcspio_sources"
+                cpio --list --quiet < "$i" >> "$TMPDIR/obscpio_sources"
+            fi
+        done
+        for i in "$DIR_TO_CHECK/"*; do
+            if [ -d "$i" ]; then
+                echo "${i##*/}" >> "$TMPDIR/obscpio_sources"
             fi
         done
     fi
 
-    cat "$TMPDIR/obcspio_sources"
+    cat "$TMPDIR/obscpio_sources"
 }
 
 check_tracked()
 {
     local file=${1##*/}
-
+    if grep -q "^$file" "$TMPDIR/moveassettargets"; then
+        # it will generated at build time
+        return 0
+    fi
     if test "$OSC_MODE" = "true" ; then
         if test -x "$(type -p git)" && test -d "$DIR_TO_CHECK/.git"; then
             if git --git-dir="$DIR_TO_CHECK/.git" ls-files --error-unmatch "$file" > /dev/null; then
@@ -346,6 +362,7 @@ find "$DIR_TO_CHECK" -mindepth 1 -maxdepth 1 | while read -s -r i; do
 	*~ | \
 	.git | \
 	.gitattributes | \
+	.gitmodules | \
 	.gitignore | \
 	.emacs.backup | \
 	PKGBUILD | \

--- a/helpers/spec_query
+++ b/helpers/spec_query
@@ -133,6 +133,12 @@ sub parse {
   return $descr;
 }
 
+sub print_moveassets {
+  my ($descr) = @_;
+  print "@{$descr->{'moveassets'} || []} ";
+  print "\n";
+}
+
 sub print_subpacks {
   my ($descr) = @_;
   print "@{$descr->{'subpacks'} || []} ";
@@ -173,6 +179,7 @@ EOF
 
 my $specfile;
 my $arch = 'noarch';
+my $print_moveassets;
 my $print_subpacks;
 my $print_sources;
 my $no_conditionals;
@@ -193,6 +200,8 @@ while (@ARGV) {
     $buildflavor = shift @ARGV;
   } elsif ($opt eq '--print-subpacks') {
     $print_subpacks = 1;
+  } elsif ($opt eq '--print-moveassets') {
+    $print_moveassets = 1;
   } elsif ($opt eq '--print-sources') {
     $print_sources = 1;
   } elsif ($opt eq '--no-conditionals') {
@@ -214,3 +223,4 @@ my $descr = parse($specfile, $arch, $no_conditionals, $keep_name_conditionals,
                   $unique_sources, $disambiguate_sources, $buildflavor);
 print_subpacks($descr) if $print_subpacks;
 print_sources($descr) if $print_sources;
+print_moveassets($descr) if $print_moveassets;


### PR DESCRIPTION
Either when being directly in a git clone (eg. an osc checkout) or when sources has been transfered via a submit request.

We need to be able to handle upstream source submodule here and we can not expect sources in any .osc subdirectory.

Also don't stumble over a .gitmodules file

A more solid way would be to run the download_asset handler instead, but it would take more time and IO to do so.

when having git submodules send via submit request the sources exist already in OBS storage as obscpio, but it avoids enormous disk usage waste on git lfs server due to uncompressed data blobs there.