### PR TITLE
helpers/check_dates_in_changes: Only look at the first line of entries

### DIFF
--- a/helpers/check_dates_in_changes
+++ b/helpers/check_dates_in_changes
@@ -59,7 +59,10 @@ for CHANGES in "$@" ; do
 				TROUBLE_FOUND=true
 				;;
 			esac
-            DATE=`date +%s --date "$DATESTR" 2> /dev/null`
+            if ! DATE=`date +%s --date "$DATESTR"`; then
+                  TROUBLE_FOUND=true
+                  continue
+            fi
             test $? -gt 0 -o -z "$DATE" -o "$LAST_IS_YEAR" != true -o "$DATE" -gt "$now" && {
                 echo "$CHANGES"
                 echo "ERROR: INVALID DATE \"$DATESTR\" "

--- a/helpers/check_dates_in_changes
+++ b/helpers/check_dates_in_changes
@@ -20,9 +20,15 @@ for CHANGES in "$@" ; do
 
     while read LINE ; do
         case "$LINE" in
-	  removed*) ;;
-	  *@*@*) ;;
-          *-*@*)
+          --------------*)
+            # Next line is the changelog entry header
+            read LINE
+          ;;
+          *)
+            continue
+          ;;
+        esac
+
             DATESTR=""
             LINE=${LINE#\*}
             for i in $LINE ; do
@@ -59,8 +65,6 @@ for CHANGES in "$@" ; do
                 echo "ERROR: INVALID DATE \"$DATESTR\" "
                 TROUBLE_FOUND=true
             }
-          ;;
-        esac
     done < "$CHANGES"
 done
 if test $TROUBLE_FOUND = false ; then


### PR DESCRIPTION
The previous logic looked at anything matching *-*@* which has too many
false positives. Make it look for changelog entry separators instead.

Fixes #149 