### PR TITLE
add minisign support

### DIFF
--- a/25-keyring-validate
+++ b/25-keyring-validate
@@ -19,12 +19,28 @@ if test ${#keyrings[@]} -gt 1; then
     RETURN=1
 elif test ${#keyrings[@]} -lt 1; then
     # check for missing .keyring files
-    for i in "$DIR_TO_CHECK"/*.sig "$DIR_TO_CHECK"/*.sign "$DIR_TO_CHECK"/*.asc; do
+    for i in "$DIR_TO_CHECK"/*.sig "$DIR_TO_CHECK"/*.sign "$DIR_TO_CHECK"/*.asc "$DIR_TO_CHECK"/*.minisig; do
 	test -f "$i" || continue
 	if test ! -f "${keyrings[0]}"; then
 	    echo "Warning: Need a $(basename -- "$DIR_TO_CHECK").keyring file for validating '$(basename -- $i)'"
 	fi
     done
+elif test -f "$DIR_TO_CHECK"/*.minisig; then
+    # verify minisign signatures
+    MINISIGN="minisign"
+    if ! $MINISIGN -v &> /dev/null; then
+        echo "ERROR: $MINISIGN command not available"
+        RETURN=2
+    else 
+        for i in "$DIR_TO_CHECK"/*.minisig; do
+            test -f "$i" || continue
+            validatefn=${i%.minisig}
+            if ! $MINISIGN -V -q -p "${keyrings[0]}" -x "$i" -m "$validatefn"; then
+                echo "ERROR: signature $i does not validate"
+                RETURN=2
+            fi
+        done
+    fi
 else
     # verify GPG signatures
     GPGTMP=$(mktemp -d)


### PR DESCRIPTION
Adds support for verifying minisign based signatures. Keeps the pattern of the GnuPG part of the script of using `.keyring` files, but looks for `*.minisig` files.

Testing done:

1. still validates OpenPGP signatures:

````
$ osc co devel:tools:building/cmake
$ cd devel:tools:building/cmake
$ osc service localrun source_validator
````

2. graceful exit when installing but `minisign` is not installed

````
$ ls -1
ccache-4.12.2.tar.xz
ccache-4.12.2.tar.xz.minisig
ccache.changes
ccache.keyring
ccache.spec

$ osc service localrun source_validator
WARNING: Command 'localrun' is obsolete, please use 'run' instead.
Running source_service 'source_validator' ...
/usr/lib/obs/service/source_validators/25-keyring-validate: line 34: minisign: command not found
ERROR: signature [...]/ccache/ccache-4.12.2.tar.xz.minisig does not validate
Aborting: service call failed:  /usr/lib/obs/service/source_validator --outdir [...]/ccache/tmpa67x09de.source_validator.service
````

3. validation

````
$ zypper in minisign
$ osc service localrun source_validator
WARNING: Command 'localrun' is obsolete, please use 'run' instead.
Running source_service 'source_validator' ...
````

4. verbose, dropping `-q`:

````
Signature and comment signature verified
Trusted comment: timestamp:1764182754   file:ccache-4.12.2.tar.xz       hashed
````

5. with missing `minisign` command:

````
Running source_service 'source_validator' ...
ERROR: minisign command not available
Aborting: service call failed: [...] 
````