### PR TITLE
20-files-present-and-referenced: ignore files matched by .gitignore

### DIFF
--- a/20-files-present-and-referenced
+++ b/20-files-present-and-referenced
@@ -406,6 +406,13 @@ find "$DIR_TO_CHECK" -mindepth 1 -maxdepth 1 | while read -s -r i; do
             # and source services on server side
             [ -d "$DIR_TO_CHECK/$BASE" ] && [ -d "$DIR_TO_CHECK/.old" ] && continue
 
+            # ignore files that are ignored by git
+            if test -x "$(type -p git)" && test -f "$DIR_TO_CHECK/.gitignore"; then
+                if (cd "$DIR_TO_CHECK" && git check-ignore -q --no-index "$BASE"); then
+                    continue
+                fi
+            fi
+
             warn_on_unmentioned_files "$BASE"
 
             if test "$RETURN" != "2" ; then

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ test:
 	./helpers/spec_query --no-conditionals --keep-name-conditionals --disambiguate-sources --specfile t/data/glibc.spec
 	./helpers/spec_query --no-conditionals --keep-name-conditionals --disambiguate-sources --specfile t/data/glibc.spec --buildflavor testsuite
 	./20-files-present-and-referenced t/data/x2d/
+	./t/test_gitignore.sh
 
 
 .PHONY: all install package test

--- a/t/test_gitignore.sh
+++ b/t/test_gitignore.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Test for .gitignore integration in 20-files-present-and-referenced
+
+set -e
+
+# Path to the script to test
+VALIDATOR="./20-files-present-and-referenced"
+TEST_DATA_DIR="t/data/gitignore_test"
+
+# Create test data directory if it doesn't exist
+mkdir -p "$TEST_DATA_DIR"
+trap 'rm -rf "$TEST_DATA_DIR"' EXIT
+
+# Create a dummy spec file
+cat > "$TEST_DATA_DIR/test.spec" <<EOF
+Name: test
+Version: 1.0
+Release: 0
+Summary: test
+License: MIT
+Source0: test.tar.gz
+%description
+test
+%prep
+%setup -q
+%build
+%install
+%files
+EOF
+
+touch "$TEST_DATA_DIR/test.tar.gz"
+
+# Create a .gitignore and an ignored file
+echo "ignored.txt" > "$TEST_DATA_DIR/.gitignore"
+touch "$TEST_DATA_DIR/ignored.txt"
+
+# Create an extra file that should NOT be ignored and NOT in spec
+touch "$TEST_DATA_DIR/extra.txt"
+
+echo "Running validator on $TEST_DATA_DIR..."
+OUTPUT=$(./20-files-present-and-referenced --batchmode "$TEST_DATA_DIR" 2>&1)
+
+echo "Output:"
+echo "$OUTPUT"
+
+# Verification
+RET=0
+
+if echo "$OUTPUT" | grep -q "ignored.txt"; then
+    echo "FAIL: ignored.txt should have been ignored but was mentioned in output"
+    RET=1
+fi
+
+if ! echo "$OUTPUT" | grep -q "extra.txt"; then
+    echo "FAIL: extra.txt should have been mentioned in output but was not"
+    RET=1
+fi
+
+if [ $RET -eq 0 ]; then
+    echo "SUCCESS: gitignore filtering works correctly"
+else
+    echo "FAILURE: gitignore filtering test failed"
+fi
+
+exit $RET


### PR DESCRIPTION
This prevents the script from complaining about existence of files which should be ignored according to the .gitignore rules. It uses 'git check-ignore --no-index' to check for these files. An integration test is added to verify this behavior.