### PR TITLE
check_patches_applied: Look for BuildSystem

### DIFF
--- a/30-patches-applied
+++ b/30-patches-applied
@@ -7,7 +7,9 @@ DIR_TO_CHECK="$1"
 DESTINATIONDIR="$2"
 
 test -n "$DIR_TO_CHECK" || DIR_TO_CHECK=`pwd`
-HELPERS_DIR="/usr/lib/obs/service/source_validators/helpers"
+BASE_DIR=$(dirname $0)
+BASE_DIR=${BASE_DIR:-.}
+HELPERS_DIR="$BASE_DIR/helpers"
 $HELPERS_DIR/check_input_filename "$DIR_TO_CHECK" || exit 1
 
 test -z "$DESTINATIONDIR" -a -d "$DIR_TO_CHECK/.osc" && DESTINATIONDIR="$DIR_TO_CHECK/.osc"
@@ -19,7 +21,7 @@ for i in "$DIR_TO_CHECK"/*.spec ; do
     test "$VERBOSE" = true && echo -n "."
     RETURN=0
     # WARNING only at the moment, just complain loudly ...
-    /usr/lib/obs/service/source_validators/helpers/check_patches_applied $BATCHMODE "$i" || RETURN=1
+    $HELPERS_DIR/check_patches_applied $BATCHMODE "$i" || RETURN=1
 done
 test "$VERBOSE" = true && echo "done"
 

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ test:
 	./helpers/spec_query --no-conditionals --keep-name-conditionals --disambiguate-sources --specfile t/data/cross-aarch64-gcc7.spec
 	./helpers/spec_query --no-conditionals --keep-name-conditionals --disambiguate-sources --specfile t/data/glibc.spec
 	./helpers/spec_query --no-conditionals --keep-name-conditionals --disambiguate-sources --specfile t/data/glibc.spec --buildflavor testsuite
+	./30-patches-applied t/data/declarative/
 	./20-files-present-and-referenced t/data/x2d/
 	./t/test_gitignore.sh
 

--- a/helpers/check_patches_applied
+++ b/helpers/check_patches_applied
@@ -45,6 +45,9 @@ while (<>) {
    if (/^%auto(?:setup|patch)\b/) { # automatically applies all patches
 	exit(0);
    }
+   if (/^BuildSystem:/) { # automatically applies all patches, in declarative build system
+	exit(0);
+   }
    if (/^([\s]*)?%[Pp]atch/ || /^([\s]*#[\s#]*)%?%[Pp]atch/ || /^#[Pp]atch/) {
 	my $applied = (/^[\s]*#/) ? 2 :1;
 	my @line = split (/\s+/,$_);


### PR DESCRIPTION
The default %prep for declarative build systems [1] uses %autosetup, so we can assume that patches are applied when using "BuildSystem".

[1] https://rpm-software-management.github.io/rpm/manual/buildsystem.html

Fix https://github.com/openSUSE/obs-service-source_validator/issues/156